### PR TITLE
DM-10920: Add whitespace flex to lsstdoc regexes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,12 @@
 Change Log
 ##########
 
-[0.1.0] - (2016-05-24)
+[0.1.1] - (2017-06-13)
+======================
+
+- Make regular expressions for parsing lsstdoc TeX documents more flexible with respect to internal whitespace (`DM-10920 <https://jira.lsstcorp.org/browse/DM-10920>`_).
+
+[0.1.0] - (2017-05-24)
 ======================
 
 - Initial version.

--- a/metasrc/tex/lsstdoc.py
+++ b/metasrc/tex/lsstdoc.py
@@ -6,23 +6,26 @@ import re
 # Title regular expression
 # \\title{Title of document}"
 TITLE_PATTERN = re.compile(
-    r"\\title"  # title command
+    r"\\title\s*"  # title command, with optional whitespace
     r"(?:\[(?P<short_title>.*?)\])?"  # optional short title
+    r"\s*"  # optional whitespace between items, before braces
     r"{(?P<title>.*?)}")  # primary title
 
 # Author regular expression
 AUTHOR_PATTERN = re.compile(
     r"\\author"
+    r"\s*"  # optional whitespace between items, before braces
 )
 
 # Abstract regular expression
 ABSTRACT_PATTERN = re.compile(
     r"\\setDocAbstract"
+    r"\s*"  # optional whitespace after command, before braces
 )
 
 # Document reference (handle) regular expression
 DOCREF_PATTERN = re.compile(
-    r"\\setDocRef{(?P<handle>.*?)}"
+    r"\\setDocRef\s*{(?P<handle>.*?)}"
 )
 
 

--- a/tests/test_lsstdoc.py
+++ b/tests/test_lsstdoc.py
@@ -47,3 +47,45 @@ def test_sample_handle(ldm_nnn_data):
     assert lsstdoc.handle == 'LDM-nnn'
     assert lsstdoc.series == 'LDM'
     assert lsstdoc.serial == 'nnn'
+
+
+def test_title_variations():
+    """Test variations on the title command's formatting."""
+    # Test with whitespace in title command
+    input_txt = "\\title    [Test Plan]  { \product ~Test Plan}"
+    lsstdoc = LsstDoc(input_txt)
+    assert lsstdoc.title == " \product ~Test Plan"
+    assert lsstdoc.short_title == "Test Plan"
+
+
+def test_author_variations():
+    """Test variations on the author command's formatting."""
+    input_txt = ("\\author   {William O'Mullane, Mario Juric, "
+                 "Frossie Economou}"
+                 "                  % the author(s)")
+    lsstdoc = LsstDoc(input_txt)
+    assert lsstdoc.authors == ["William O'Mullane",
+                               "Mario Juric",
+                               "Frossie Economou"]
+
+
+def test_handle_variations():
+    """Test variations on the handle command's formatting."""
+    input_txt = "\setDocRef      {LDM-503} % the reference code "
+    lsstdoc = LsstDoc(input_txt)
+    assert lsstdoc.handle == "LDM-503"
+
+
+def test_abstract_variations():
+    """Test variations on the abstract command's formatting."""
+    input_txt = ("\setDocAbstract {\n"
+                 "This is the  Test Plan for \product. In it we define terms "
+                 "associated with testing and further test specifications for "
+                 "specific items.}")
+    expected_abstract = (
+        "This is the  Test Plan for \product. In it we define terms "
+        "associated with testing and further test specifications for "
+        "specific items."
+    )
+    lsstdoc = LsstDoc(input_txt)
+    assert lsstdoc.abstract == expected_abstract


### PR DESCRIPTION
The `\s*` regular expression allows us to deal with whitepace intermixed inside a tex command pattern, like

```
\title    [Test Plan]  { \product ~Test Plan}
```

Note that these regular expressions will need to be replaced with a fully-fledged tokenizer soon; regular expressions aren't well suited to parsing tex source.