### PR TITLE
DM-10961: Filter latex source (comments, whitespace, inputs, simple macros)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Change Log
 ##########
 
+Unreleased
+==========
+
+- Add new ``metasrc.tex.texnormalizer.read_tex_file`` function that reads a tex file and inserts reference files into the source.
+  Works with ``\input`` and ``\include`` commands.
+- New support for macro resolution in TeX source.
+  The ``metasrc.tex.scraper.get_macros`` to scrape TeX macro definitions from ``\def`` and ``\newcommand`` commands.
+  The ``metasrc.tex.texnormalizer.replace_macros`` function takes the output from ``get_macros`` and replaces macros in TeX source with the macro content.
+  Only static macros (those without arguments) are supported by these functions.
+
 [0.1.2] - (2017-06-17)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change Log
 ##########
 
+[0.1.2] - (2017-06-17)
+======================
+
+- Add new ``metasrc.tex.texnormalizer`` module with ``remove_comments()` and ``remove_trailing_whitespace()`` functions.
+  Projects can use these functions in a pipeline to clean TeX source to make subsequent parsing tasks easier.
+  (`DM-10961 <https://jira.lsstcorp.org/browse/DM-10961>`)
+
 [0.1.1] - (2017-06-13)
 ======================
 

--- a/metasrc/tex/scraper.py
+++ b/metasrc/tex/scraper.py
@@ -1,0 +1,101 @@
+"""TeX source scraping.
+"""
+
+import re
+
+
+# Regular expressions for "\def \name {content}"
+# Expects the entire command to be on one line.
+DEF_PATTERN = re.compile(
+    r"\\def\s*"  # def command with optional whitespace
+    r"(?P<name>\\[a-zA-Z]*?)\s*"  # macro name with optional whitespace
+    r"{(?P<content>.*?)}")  # macro contents
+
+# Regular expressions for "\def \name {content}"
+# Does not handle arguments.
+NEWCOMMAND_PATTERN = re.compile(
+    r"\\newcommand\s*"  # def command with optional whitespace
+    r"{\s*(?P<name>\\[a-zA-Z]*?)\s*}\s*"  # macro name with optional whitespace
+    r"{(?P<content>.*?)}")  # macro contents
+
+
+def get_macros(tex_source):
+    """Get all macro definitions from TeX source, supporting multiple
+    declaration patterns.
+
+    Parameters
+    ----------
+    tex_source : `str`
+        TeX source content.
+
+    Returns
+    -------
+    macros : `dict`
+        Keys are macro names (including leading ``\``) and values are the
+        content (as `str`) of the macros.
+
+    Notes
+    -----
+    This function uses the following function to scrape macros of different
+    types:
+
+    - `get_def_macros`
+    - `get_newcommand_macros`
+
+    This macro scraping has the following caveats:
+
+    - Macro definition (including content) must all occur on one line.
+    - Macros with arguments are not supported.
+    """
+    macros = {}
+    macros.update(get_def_macros(tex_source))
+    macros.update(get_newcommand_macros(tex_source))
+    return macros
+
+
+def get_def_macros(tex_source):
+    """Get all ``\def`` macro definition from TeX source.
+
+    Parameters
+    ----------
+    tex_source : `str`
+        TeX source content.
+
+    Returns
+    -------
+    macros : `dict`
+        Keys are macro names (including leading ``\``) and values are the
+        content (as `str`) of the macros.
+
+    Notes
+    -----
+    ``\def`` macros with arguments are not supported.
+    """
+    macros = {}
+    for match in DEF_PATTERN.finditer(tex_source):
+        macros[match.group('name')] = match.group('content')
+    return macros
+
+
+def get_newcommand_macros(tex_source):
+    r"""Get all ``\newcommand`` macro definition from TeX source.
+
+    Parameters
+    ----------
+    tex_source : `str`
+        TeX source content.
+
+    Returns
+    -------
+    macros : `dict`
+        Keys are macro names (including leading ``\``) and values are the
+        content (as `str`) of the macros.
+
+    Notes
+    -----
+    ``\newcommand`` macros with arguments are not supported.
+    """
+    macros = {}
+    for match in NEWCOMMAND_PATTERN.finditer(tex_source):
+        macros[match.group('name')] = match.group('content')
+    return macros

--- a/metasrc/tex/texnormalizer.py
+++ b/metasrc/tex/texnormalizer.py
@@ -125,3 +125,48 @@ def process_inputs(tex_source, root_dir=None):
     tex_source = input_pattern.sub(_sub_line, tex_source)
     tex_source = include_pattern.sub(_sub_line, tex_source)
     return tex_source
+
+
+def replace_macros(tex_source, macros):
+    """Replace macros in the TeX source with their content.
+
+    Parameters
+    ----------
+    tex_source : `str`
+        TeX source content.
+    macros : `dict`
+        Keys are macro names (including leading ``\``) and values are the
+        content (as `str`) of the macros. See
+        `metasrc.tex.scraper.get_macros`.
+
+    Returns
+    -------
+    tex_source : `str`
+        TeX source with known macros replaced.
+
+    Notes
+    -----
+    Macros with arguments are not supported.
+
+    Examples
+    --------
+    >>> macros = {r'\handle': 'LDM-nnn'}
+    >>> sample = r'This is document \handle.'
+    >>> replace_macros(sample, macros)
+    'This is document LDM-nnn.'
+
+    Any trailing slash after the macro command is also replaced by this
+    function.
+
+    >>> macros = {'\\product': 'Data Management'}
+    >>> sample = '\\title    [Test Plan]  { \\product\\ Test Plan}'
+    >>> replace_macros(sample, macros)
+    '\\title    [Test Plan]  { Data Management Test Plan}'
+    """
+    for macro_name, macro_content in macros.items():
+        # '\' prefix is needed to escape and match the '\' in the macro name.
+        # '\\?' suffix matches an optional trailing '\' that might be used
+        # for spacing.
+        pattern = '\\' + macro_name + '\\\\?'
+        tex_source = re.sub(pattern, macro_content, tex_source)
+    return tex_source

--- a/metasrc/tex/texnormalizer.py
+++ b/metasrc/tex/texnormalizer.py
@@ -1,7 +1,16 @@
 """Functions for normalizing TeX source.
 """
 
+import logging
+import os
 import re
+
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+# Regular expressions
+input_pattern = re.compile(r'\\input{(.*?)}')
+include_pattern = re.compile(r'\\include{(.*?)}')
 
 
 def remove_comments(tex_source):
@@ -36,3 +45,83 @@ def remove_trailing_whitespace(tex_source):
     """
     # Expression via https://stackoverflow.com/a/17350806
     return re.sub(r'\s+$', '', tex_source, flags=re.M)
+
+
+def read_tex_file(root_filepath, root_dir=None):
+    """Read a TeX file, automatically processing and normalizing it
+    (including other input files, removing comments, and deleting trailing
+    whitespace).
+
+    Parameters
+    ----------
+    root_filepath : `str`
+        Filepath to a TeX file.
+    root_dir : `str`
+        Root directory of the TeX project. This only needs to be set when
+        recursively reading in ``\input`` or ``\include`` files.
+
+    Returns
+    -------
+    tex_source : `str`
+        TeX source.
+    """
+    with open(root_filepath, 'r') as f:
+        tex_source = f.read()
+
+    if root_dir is None:
+        root_dir = os.path.dirname(root_filepath)
+
+    # Text processing pipline
+    tex_source = remove_comments(tex_source)
+    tex_source = remove_trailing_whitespace(tex_source)
+    tex_source = process_inputs(tex_source, root_dir=root_dir)
+
+    return tex_source
+
+
+def process_inputs(tex_source, root_dir=None):
+    """Insert referenced TeX file contents (from  ``\input`` and ``\include``
+    commands) into the source.
+
+    Parameters
+    ----------
+    tex_source : `str`
+        TeX source where referenced source files will be found and inserted.
+    root_dir : `str`, optional
+        Name of the directory containing the TeX project's root file. Files
+        referenced by TeX ``\input`` and ``\include`` commands are relative to
+        this directory. If not set, the current working directory is assumed.
+
+    Returns
+    -------
+    tex_source : `str`
+        TeX source.
+
+    See also
+    --------
+    `read_tex_file`
+        Recommended API for reading a root TeX source file and inserting
+        referenced files.
+    """
+    logger = logging.getLogger(__name__)
+
+    def _sub_line(match):
+        """Function to be used with re.sub to inline files for each match."""
+        fname = match.group(1)
+        if not fname.endswith('.tex'):
+            full_fname = ".".join((fname, 'tex'))
+        else:
+            full_fname = fname
+        full_path = os.path.abspath(os.path.join(root_dir, full_fname))
+
+        try:
+            included_source = read_tex_file(full_path, root_dir=root_dir)
+        except IOError:
+            logger.error("Cannot open {0} for inclusion".format(full_path))
+            raise
+        else:
+            return included_source
+
+    tex_source = input_pattern.sub(_sub_line, tex_source)
+    tex_source = include_pattern.sub(_sub_line, tex_source)
+    return tex_source

--- a/metasrc/tex/texnormalizer.py
+++ b/metasrc/tex/texnormalizer.py
@@ -19,3 +19,20 @@ def remove_comments(tex_source):
     """
     # Expression via http://stackoverflow.com/a/13365453
     return re.sub(r'(?<!\\)%.*$', r'', tex_source, flags=re.M)
+
+
+def remove_trailing_whitespace(tex_source):
+    """Delete trailing whitespace from TeX source.
+
+    Parameters
+    ----------
+    tex_source : str
+        TeX source content.
+
+    Returns
+    -------
+    tex_source : str
+        TeX source without trailing whitespace.
+    """
+    # Expression via https://stackoverflow.com/a/17350806
+    return re.sub(r'\s+$', '', tex_source, flags=re.M)

--- a/metasrc/tex/texnormalizer.py
+++ b/metasrc/tex/texnormalizer.py
@@ -1,0 +1,21 @@
+"""Functions for normalizing TeX source.
+"""
+
+import re
+
+
+def remove_comments(tex_source):
+    """Delete latex comments from TeX source.
+
+    Parameters
+    ----------
+    tex_source : str
+        TeX source content.
+
+    Returns
+    -------
+    tex_source : str
+        TeX source without comments.
+    """
+    # Expression via http://stackoverflow.com/a/13365453
+    return re.sub(r'(?<!\\)%.*$', r'', tex_source, flags=re.M)

--- a/tests/data/texinputs/LDM-nnn.tex
+++ b/tests/data/texinputs/LDM-nnn.tex
@@ -1,0 +1,45 @@
+\documentclass[DM,lsstdraft,toc]{lsstdoc}
+
+% Package imports go here
+
+% Local commands go here
+
+\title[Short title]{Title of document}
+
+\author{
+A.~Author,
+B.~Author,
+and
+C.~Author}
+
+\setDocRef{LDM-nnn}
+\date{\today}
+
+% Optional
+\setDocCurator{The Curator of this Document}
+
+\input{abstract.tex}
+
+% Change history defined here. Will be inserted into
+% correct place with \maketitle
+% OLDEST FIRST: VERSION, DATE, DESCRIPTION, OWNER NAME
+\setDocChangeRecord{%
+\addtohist{1}{2017-09-10}{Initial release. Based on Gaia examples.}{Tim Jenness}
+\addtohist{2}{yyyy-mm-dd}{Future changes}{Future person}
+}
+
+\begin{document}
+
+% Create the title page
+% Table of contents will be added automatically if "toc" class option
+% is used.
+\maketitle
+
+\include{content/intro.tex}
+
+% Include all the relevant bib files.
+% lsst is for DocuShare and DMTN entries.
+% refs_ads is for entries coming from ADS.
+\bibliography{lsst,refs,books,refs_ads}
+
+\end{document}

--- a/tests/data/texinputs/abstract.tex
+++ b/tests/data/texinputs/abstract.tex
@@ -1,0 +1,5 @@
+\setDocAbstract{%
+This document demonstrates how to use the LSST \LaTeX\ class files to make Data Management
+documents. Build this document in the normal way, making sure that the class file is
+available in the \LaTeX\ load path.
+}

--- a/tests/data/texinputs/content/intro.tex
+++ b/tests/data/texinputs/content/intro.tex
@@ -1,0 +1,18 @@
+\section{Introduction}
+
+Now write your document as you would normally write it.
+Different citation schemes are supported, and the default bibliography style is declared by the class.
+
+\verb|\citellp|: \citellp{LPM-17, LSE-30} \\
+\verb|\citell|: (SRD; \citell{LPM-17,LSE-29}) \\
+\verb|\citep[][]|: \citep[e.g.,][are interesting]{LPM-17,LSE-29} \\
+\verb|\cite|: \cite{LPM-17,LSE-29}
+
+Font checking: \texttt{Fixed width font}.
+
+Math checking: $A = \pi r^2 \mathrm{(math roman)}$
+
+% Include all the relevant bib files.
+% lsst is for DocuShare and DMTN entries.
+% refs_ads is for entries coming from ADS.
+\bibliography{lsst,refs,books,refs_ads}

--- a/tests/test_tex_scraper.py
+++ b/tests/test_tex_scraper.py
@@ -1,0 +1,37 @@
+"""Tests for metasrc.tex.scraper.
+"""
+
+from metasrc.tex import scraper
+
+
+def test_get_def_macros():
+    sample = r"\def \name {content}"
+    macros = scraper.get_def_macros(sample)
+
+    assert r'\name' in macros
+    assert macros[r'\name'] == 'content'
+
+
+def test_get_def_macros_LDM_503():
+    sample = ('\documentclass[DM,STP,toc]{lsstdoc}\n'
+              '%set the WP number or product here for the requirements\n'
+              '\def\product{Data Management}\n'
+              '\def\cycle{S17}\n')
+    macros = scraper.get_def_macros(sample)
+
+    assert macros[r'\product'] == 'Data Management'
+    assert macros[r'\cycle'] == 'S17'
+
+
+def test_get_newcommand_macros():
+    sample = r"\newcommand {\name} {content}"
+    macros = scraper.get_newcommand_macros(sample)
+    assert macros[r'\name'] == 'content'
+
+    sample = r"\newcommand { \name } {content}"
+    macros = scraper.get_newcommand_macros(sample)
+    assert macros[r'\name'] == 'content'
+
+    sample = r"\newcommand{\name}{content}"
+    macros = scraper.get_newcommand_macros(sample)
+    assert macros[r'\name'] == 'content'

--- a/tests/test_texnormalizer.py
+++ b/tests/test_texnormalizer.py
@@ -67,3 +67,23 @@ def test_read_tex_file():
     # verify that input'd and include'd content is present
     assert re.search(r'\\setDocAbstract', tex_source) is not None
     assert re.search(r'\\section{Introduction}', tex_source) is not None
+
+
+def test_replace_macros():
+    sample = (
+        r"\def \product {Data Management}" + "\n"
+        r"\title    [Test Plan]  { \product\ Test Plan}" + "\n"
+        r"\setDocAbstract {" + "\n"
+        r"This is the  Test Plan for \product.}")
+
+    expected = (
+        r"\def Data Management {Data Management}" + "\n"
+        r"\title    [Test Plan]  { Data Management Test Plan}" + "\n"
+        r"\setDocAbstract {" + "\n"
+        r"This is the  Test Plan for Data Management.}")
+
+    macros = {r'\product': 'Data Management'}
+    tex_source = texnormalizer.replace_macros(sample, macros)
+    assert re.search(r'\\product', sample) is not None  # sanity check
+    assert re.search(r'\\product', tex_source) is None
+    assert tex_source == expected

--- a/tests/test_texnormalizer.py
+++ b/tests/test_texnormalizer.py
@@ -1,6 +1,9 @@
 """Tests for the metasrc.tex.texnormalizer module.
 """
 
+import os
+import re
+
 import metasrc.tex.texnormalizer as texnormalizer
 
 
@@ -54,3 +57,13 @@ def test_multi_line_trailing_whitespace():
     expected = ("First line.\n"
                 "Second line.")
     assert texnormalizer.remove_trailing_whitespace(sample) == expected
+
+
+def test_read_tex_file():
+    project_dir = os.path.join(os.path.dirname(__file__), 'data', 'texinputs')
+    root_filepath = os.path.join(project_dir, 'LDM-nnn.tex')
+    tex_source = texnormalizer.read_tex_file(root_filepath)
+
+    # verify that input'd and include'd content is present
+    assert re.search(r'\\setDocAbstract', tex_source) is not None
+    assert re.search(r'\\section{Introduction}', tex_source) is not None

--- a/tests/test_texnormalizer.py
+++ b/tests/test_texnormalizer.py
@@ -1,0 +1,42 @@
+"""Tests for the metasrc.tex.texnormalizer module.
+"""
+
+import metasrc.tex.texnormalizer as texnormalizer
+
+
+def test_remove_comments_abstract():
+    sample = ("\setDocAbstract{%\n"
+              " The LSST Data Management System (DMS) is a set of services\n"
+              " employing a variety of software components running on\n"
+              " computational and networking infrastructure that combine to\n"
+              " deliver science data products to the observatory's users and\n"
+              " support observatory operations.  This document describes the\n"
+              " components, their service instances, and their deployment\n"
+              " environments as well as the interfaces among them, the rest\n"
+              " of the LSST system, and the outside world.\n"
+              "}")
+    expected = (
+        "\setDocAbstract{\n"
+        " The LSST Data Management System (DMS) is a set of services\n"
+        " employing a variety of software components running on\n"
+        " computational and networking infrastructure that combine to\n"
+        " deliver science data products to the observatory's users and\n"
+        " support observatory operations.  This document describes the\n"
+        " components, their service instances, and their deployment\n"
+        " environments as well as the interfaces among them, the rest\n"
+        " of the LSST system, and the outside world.\n"
+        "}")
+    assert texnormalizer.remove_comments(sample) == expected
+
+
+def test_escaped_remove_comments():
+    """Test remove_comments where a "%" is escaped."""
+    sample = "The uncertainty is 5\%.  % a comment"
+    expected = "The uncertainty is 5\%.  "
+    assert texnormalizer.remove_comments(sample) == expected
+
+
+def test_single_line_remove_comments():
+    sample = "This is content.  % a comment"
+    expected = "This is content.  "
+    assert texnormalizer.remove_comments(sample) == expected

--- a/tests/test_texnormalizer.py
+++ b/tests/test_texnormalizer.py
@@ -40,3 +40,17 @@ def test_single_line_remove_comments():
     sample = "This is content.  % a comment"
     expected = "This is content.  "
     assert texnormalizer.remove_comments(sample) == expected
+
+
+def test_remove_single_line_trailing_whitespace():
+    sample = "This is content.    "
+    expected = "This is content."
+    assert texnormalizer.remove_trailing_whitespace(sample) == expected
+
+
+def test_multi_line_trailing_whitespace():
+    sample = ("First line.    \n"
+              "Second line. ")
+    expected = ("First line.\n"
+                "Second line.")
+    assert texnormalizer.remove_trailing_whitespace(sample) == expected


### PR DESCRIPTION
- [x] Filter comments from tex source.
- [x] Filter trailing whitespace from tex source.
- [x] Process `\input` and `\include`: `metasrc.tex.texnormalizer.read_tex_file()`
- [x] Process simple macros (`\def` and `\newcommand`): `metasrc.tex.scraper.get_macros()` and `metasrc.tex.texnormalizer.replace_macros()`.

Will release as `0.1.3`.