### PR TITLE
DM-11245: Add LsstDoc.is_draft property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Change Log
 ##########
 
-Unreleased
-==========
+[0.1.3] - (2017-07-12)
+======================
 
 - Add new ``metasrc.tex.texnormalizer.read_tex_file`` function that reads a tex file and inserts reference files into the source.
   Works with ``\input`` and ``\include`` commands.
@@ -11,6 +11,8 @@ Unreleased
   The ``metasrc.tex.scraper.get_macros`` to scrape TeX macro definitions from ``\def`` and ``\newcommand`` commands.
   The ``metasrc.tex.texnormalizer.replace_macros`` function takes the output from ``get_macros`` and replaces macros in TeX source with the macro content.
   Only static macros (those without arguments) are supported by these functions.
+- Add ``LsstDoc.is_draft`` property.
+  This property is ``True`` if the ``lsstdraft`` option is in the ``documentclass`` declaration.
 
 [0.1.2] - (2017-06-17)
 ======================

--- a/tests/test_lsstdoc.py
+++ b/tests/test_lsstdoc.py
@@ -89,3 +89,13 @@ def test_abstract_variations():
     )
     lsstdoc = LsstDoc(input_txt)
     assert lsstdoc.abstract == expected_abstract
+
+
+@pytest.mark.parametrize(
+    'sample, expected',
+    [(r'\documentclass[DM,lsstdraft,toc]{lsstdoc}', True),
+     (r'\documentclass[DM,toc]{lsstdoc}', False),
+     (r'\documentclass[DM, lsstdraft, toc]{lsstdoc}', True)])
+def test_is_draft(sample, expected):
+    lsstdoc = LsstDoc(sample)
+    assert lsstdoc.is_draft == expected


### PR DESCRIPTION
(Note: this should be merged after #3)

`LsstDoc.is_draft` is True if 'lsstdoc' is included in the `\documentclass`'s options list.