### PR TITLE
DM-12079: Extract LsstLatexDoc revision date from LaTeX source or Git

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Change Log
 ##########
 
+0.2.1 (2017-10-09)
+==================
+
+- Add a ``LsstLatexDoc.revision_datetime`` attribute to access the latest revision date metadata of a LaTeX document.
+  This property uses a set value in the ``\date`` command, if available.
+  Otherwise it falls back to the timestamp of the most recent Git commit that affected content (files with ``tex``, ``bib``, ``pdf``, ``png``, and ``jpg`` extensions).
+  The final fallback is the current time.
+  The ``LsstLatexDoc.revision_datetime_source`` attribute describes how the date was computed: ``tex``, ``git``, or ``now``.
+- New ``metasrc.git.timestamp`` module for accessing commit dates from a local Git repository.
+- New dependency on ``pytz``.
+- New dependency on ``GitPython``.
+
 0.2.0 (2017-09-28)
 ==================
 

--- a/metasrc/git/timestamp.py
+++ b/metasrc/git/timestamp.py
@@ -1,0 +1,191 @@
+"""Utilities for extracting commit timestamps from Git repositories.
+"""
+
+__all__ = ('read_git_commit_timestamp', 'read_git_commit_timestamp_for_file',
+           'get_content_commit_date')
+
+import itertools
+import logging
+import os
+
+import git
+
+
+def read_git_commit_timestamp(repo_path=None, repo=None):
+    """Obtain the timestamp from the current head commit of a Git repository.
+
+    Parameters
+    ----------
+    repo_path : `str`, optional
+        Path to the Git repository. Leave as `None` to use the current working
+        directory.
+
+    Returns
+    -------
+    commit_timestamp : `datetime.datetime`
+        The datetime of the head commit.
+    """
+    if repo is None:
+        repo = git.repo.base.Repo(path=repo_path,
+                                  search_parent_directories=True)
+    head_commit = repo.head.commit
+    return head_commit.committed_datetime
+
+
+def read_git_commit_timestamp_for_file(filepath, repo_path=None, repo=None):
+    """Obtain the timestamp for the most recent commit to a given file in a
+    Git repository.
+
+    Parameters
+    ----------
+    filepath : `str`
+        Absolute or repository-relative path for a file.
+    repo_path : `str`, optional
+        Path to the Git repository. Leave as `None` to use the current working
+        directory or if a ``repo`` argument is provided.
+    repo : `git.Repo`, optional
+        A `git.Repo` instance.
+
+    Returns
+    -------
+    commit_timestamp : `datetime.datetime`
+        The datetime of the most recent commit to the given file.
+
+    Raises
+    ------
+    IOError
+        Raised if the ``filepath`` does not exist in the Git repository.
+    """
+    logger = logging.getLogger(__name__)
+
+    if repo is None:
+        repo = git.repo.base.Repo(path=repo_path,
+                                  search_parent_directories=True)
+    repo_path = repo.working_tree_dir
+
+    head_commit = repo.head.commit
+
+    # filepath relative to the repo path
+    logger.debug('Using Git repo at %r', repo_path)
+    filepath = os.path.relpath(
+        os.path.abspath(filepath),
+        start=repo_path)
+    logger.debug('Repo-relative filepath is %r', filepath)
+
+    # Most recent commit datetime of the given file.
+    # Don't use head_commit.iter_parents because then it skips the
+    # commit of a file that's added but never modified.
+    for commit in head_commit.iter_items(repo,
+                                         head_commit,
+                                         [filepath],
+                                         skip=0):
+        return commit.committed_datetime
+
+    # Only get here if git could not find the file path in the history
+    raise IOError('File {} not found'.format(filepath))
+
+
+def get_content_commit_date(extensions, acceptance_callback=None,
+                            root_dir='.'):
+    """Get the datetime for the most recent commit to a project that
+    affected certain types of content.
+
+    Parameters
+    ----------
+    extensions : sequence of 'str'
+        Extensions of files to consider in getting the most recent commit
+        date. For example, ``('rst', 'svg', 'png')`` are content extensions
+        for a Sphinx project. **Extension comparision is case sensitive.** add
+        uppercase variants to match uppercase extensions.
+    acceptance_callback : callable
+        Callable function whose sole argument is a file path, and returns
+        `True` or `False` depending on whether the file's commit date should
+        be considered or not. This callback is only run on files that are
+        included by ``extensions``. Thus this callback is a way to exclude
+        specific files that would otherwise be included by their extension.
+    root_dir : 'str`, optional
+        Only content contained within this root directory is considered.
+        This directory must be, or be contained by, a Git repository. This is
+        the current working directory by default.
+
+    Returns
+    -------
+    commit_date : `datetime.datetime`
+        Datetime of the most recent content commit.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if no content files are found.
+    """
+    logger = logging.getLogger(__name__)
+
+    def _null_callback(_):
+        return True
+
+    if acceptance_callback is None:
+        acceptance_callback = _null_callback
+
+    # Cache the repo object for each query
+    root_dir = os.path.abspath(root_dir)
+    repo = git.repo.base.Repo(path=root_dir, search_parent_directories=True)
+
+    # Iterate over all files with all file extensions, looking for the
+    # newest commit datetime.
+    newest_datetime = None
+    iters = [_iter_filepaths_with_extension(ext, root_dir=root_dir)
+             for ext in extensions]
+    for content_path in itertools.chain(*iters):
+        content_path = os.path.abspath(os.path.join(root_dir, content_path))
+
+        if acceptance_callback(content_path):
+            logger.debug('Found content path %r', content_path)
+            try:
+                commit_datetime = read_git_commit_timestamp_for_file(
+                    content_path, repo=repo)
+            except IOError:
+                logger.warning(
+                    'Count not get commit for %r, skipping',
+                    content_path)
+                continue
+
+            if not newest_datetime or commit_datetime > newest_datetime:
+                # Seed initial newest_datetime
+                # or set a newer newest_datetime
+                newest_datetime = commit_datetime
+
+    if newest_datetime is None:
+        raise RuntimeError('No content files found in {}'.format(root_dir))
+
+    return newest_datetime
+
+
+def _iter_filepaths_with_extension(extname, root_dir='.'):
+    """Iterative over relative filepaths of files in a directory, and
+    sub-directories, with the given extension.
+
+    Parameters
+    ----------
+    extname : `str`
+        Extension name (such as 'txt' or 'rst'). Extension comparison is
+        case sensitive.
+    root_dir : 'str`, optional
+        Root directory. Current working directory by default.
+
+    Yields
+    ------
+    filepath : `str`
+        File path, relative to ``root_dir``, with the given extension.
+    """
+    # needed for comparison with os.path.splitext
+    if not extname.startswith('.'):
+        extname = '.' + extname
+
+    root_dir = os.path.abspath(root_dir)
+
+    for dirname, sub_dirnames, filenames in os.walk(root_dir):
+        for filename in filenames:
+            if os.path.splitext(filename)[-1] == extname:
+                full_filename = os.path.join(dirname, filename)
+                rel_filepath = os.path.relpath(full_filename, start=root_dir)
+                yield rel_filepath

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         'panflute==1.10.6',
         'aiohttp>=2.2.5',
         'pybtex>=0.21',
-        'GitPython>=2.1.7'
+        'GitPython>=2.1.7',
+        'pytz'
     ],
     cmdclass=versioneer.get_cmdclass(),
     # package_data={},

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         'pypandoc>=1.4',
         'panflute==1.10.6',
         'aiohttp>=2.2.5',
-        'pybtex>=0.21'
+        'pybtex>=0.21',
+        'GitPython>=2.1.7'
     ],
     cmdclass=versioneer.get_cmdclass(),
     # package_data={},

--- a/tests/test_git_timestamp.py
+++ b/tests/test_git_timestamp.py
@@ -1,0 +1,49 @@
+"""Tests for the metasrc.git.timestamp.
+"""
+
+from datetime import datetime
+import os
+
+import pytest
+
+from metasrc.git.timestamp import (read_git_commit_timestamp_for_file,
+                                   _iter_filepaths_with_extension,
+                                   get_content_commit_date)
+
+
+def test_git_commit_timestamp_for_file():
+    """Smoke-test read_git_commit_timestamp_for_file with README.rst in
+    metasrc's own Git repo.
+    """
+    test_dir = os.path.dirname(__file__)
+    readme_path = os.path.abspath(os.path.join(test_dir, '..', 'README.rst'))
+    timestamp = read_git_commit_timestamp_for_file(readme_path)
+    assert isinstance(timestamp, datetime)
+
+
+def test_git_commit_timestamp_for_file_nonexistent():
+    """Smoke-test read_git_commit_timestamp_for_file with README.rst in
+    metasrc's own Git repo.
+    """
+    path = 'doesnt_exist.txt'
+    with pytest.raises(IOError):
+        read_git_commit_timestamp_for_file(path)
+
+
+def test_iter_filepaths_with_extension():
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    filepaths = _iter_filepaths_with_extension('py', root_dir=repo_dir)
+    assert os.path.join('tests', 'test_git_timestamp.py') in filepaths
+    assert 'README.rst' not in filepaths
+
+
+def test_get_project_content_commit_date():
+    """Smoke test using the metasrc repo.
+    """
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    commit_date = get_content_commit_date(('rst', 'py'), root_dir=repo_dir)
+    assert isinstance(commit_date, datetime)
+
+    # Verify file search is case sensitive
+    with pytest.raises(RuntimeError):
+        get_content_commit_date(('RST', 'PY'), root_dir=repo_dir)

--- a/tests/test_lsstdoc_dmtn_036.py
+++ b/tests/test_lsstdoc_dmtn_036.py
@@ -1,6 +1,7 @@
 """Test LsstLatexDoc using sample data from DMTN-036.tex.
 """
 
+import datetime
 import os
 import pytest
 from metasrc.tex.lsstdoc import LsstLatexDoc
@@ -90,7 +91,7 @@ ATTRIBUTES = [
     ('is_draft', IS_DRAFT),
     ('handle', HANDLE),
     ('series', SERIES),
-    ('serial', SERIAL),
+    ('serial', SERIAL)
 ]
 
 
@@ -103,3 +104,9 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""DMTN-036 uses the \today value for \date."""
+    assert isinstance(lsstdoc.revision_datetime, datetime.datetime)
+    assert lsstdoc.revision_datetime_source == 'git'

--- a/tests/test_lsstdoc_dmtn_036.py
+++ b/tests/test_lsstdoc_dmtn_036.py
@@ -107,6 +107,6 @@ def test_attribute(lsstdoc, attribute, expected):
 
 
 def test_revision_date(lsstdoc):
-    r"""DMTN-036 uses the \today value for \date."""
+    r"""DMTN-036 is a draft, so it falls back to Git."""
     assert isinstance(lsstdoc.revision_datetime, datetime.datetime)
     assert lsstdoc.revision_datetime_source == 'git'

--- a/tests/test_lsstdoc_dmtn_044.py
+++ b/tests/test_lsstdoc_dmtn_044.py
@@ -93,3 +93,10 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""DMTN-044 sets a 2017-06-26 value for \setDocDate, which is deprecated
+    and ignored (so it falls back to Git).
+    """
+    assert lsstdoc.revision_datetime_source == 'git'

--- a/tests/test_lsstdoc_dmtr_31.py
+++ b/tests/test_lsstdoc_dmtr_31.py
@@ -1,8 +1,10 @@
 """Test LsstLatexDoc using sample data from DMTR-31.tex.
 """
 
+import datetime
 import os
 import pytest
+import pytz
 from metasrc.tex.lsstdoc import LsstLatexDoc
 
 TITLE = "S17B HSC PDR1 Reprocessing Report"
@@ -86,3 +88,10 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""DMTR-31 uses a set value for \date."""
+    expected_datetime = datetime.datetime(2017, 8, 28, 7, 0, tzinfo=pytz.utc)
+    assert lsstdoc.revision_datetime == expected_datetime
+    assert lsstdoc.revision_datetime_source == 'tex'

--- a/tests/test_lsstdoc_ldm_151.py
+++ b/tests/test_lsstdoc_ldm_151.py
@@ -1,8 +1,10 @@
 """Test LsstLatexDoc using sample data from LDM-151.tex.
 """
 
+import datetime
 import os
 import pytest
+import pytz
 from metasrc.tex.lsstdoc import LsstLatexDoc
 
 TITLE = "Data Management Science Pipelines Design"
@@ -150,3 +152,10 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""LDM-151 uses a set value for \date."""
+    expected_datetime = datetime.datetime(2017, 7, 19, 7, 0, tzinfo=pytz.utc)
+    assert lsstdoc.revision_datetime == expected_datetime
+    assert lsstdoc.revision_datetime_source == 'tex'

--- a/tests/test_lsstdoc_ldm_nnn.py
+++ b/tests/test_lsstdoc_ldm_nnn.py
@@ -85,6 +85,8 @@ def test_attribute(lsstdoc, attribute, expected):
 
 
 def test_revision_date(lsstdoc):
-    r"""LDM-nnn uses \today value for \date."""
+    r"""LDM-nnn is a draft so it falls back to git (would anyway since
+    ``\date`` is ``\today``).
+    """
     assert isinstance(lsstdoc.revision_datetime, datetime.datetime)
     assert lsstdoc.revision_datetime_source == 'git'

--- a/tests/test_lsstdoc_ldm_nnn.py
+++ b/tests/test_lsstdoc_ldm_nnn.py
@@ -1,6 +1,7 @@
 """Test LsstLatexDoc using sample data from LDM-nnn.tex.
 """
 
+import datetime
 import os
 import pytest
 from metasrc.tex.lsstdoc import LsstLatexDoc
@@ -81,3 +82,9 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""LDM-nnn uses \today value for \date."""
+    assert isinstance(lsstdoc.revision_datetime, datetime.datetime)
+    assert lsstdoc.revision_datetime_source == 'git'

--- a/tests/test_lsstdoc_lse_61.py
+++ b/tests/test_lsstdoc_lse_61.py
@@ -1,8 +1,10 @@
 """Test LsstLatexDoc using sample data from LSE-61.tex.
 """
 
+import datetime
 import os
 import pytest
+import pytz
 from metasrc.tex.lsstdoc import LsstLatexDoc
 
 TITLE = "Data Management System (DMS) Requirements"
@@ -75,3 +77,10 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""LSE-61 uses a set value for \date."""
+    expected_datetime = datetime.datetime(2017, 9, 12, 7, 0, tzinfo=pytz.utc)
+    assert lsstdoc.revision_datetime == expected_datetime
+    assert lsstdoc.revision_datetime_source == 'tex'

--- a/tests/test_lsstdoc_lse_63.py
+++ b/tests/test_lsstdoc_lse_63.py
@@ -1,8 +1,10 @@
 """Test LsstLatexDoc using sample data from LSE-63.tex.
 """
 
+import datetime
 import os
 import pytest
+import pytz
 from metasrc.tex.lsstdoc import LsstLatexDoc
 
 TITLE = "LSST Data Quality Assurance Plan"
@@ -147,3 +149,10 @@ def lsstdoc():
 @pytest.mark.parametrize('attribute,expected', ATTRIBUTES)
 def test_attribute(lsstdoc, attribute, expected):
     assert getattr(lsstdoc, attribute) == expected
+
+
+def test_revision_date(lsstdoc):
+    r"""LSE-63 uses a set value for \date."""
+    expected_datetime = datetime.datetime(2017, 5, 17, 7, 0, tzinfo=pytz.utc)
+    assert lsstdoc.revision_datetime == expected_datetime
+    assert lsstdoc.revision_datetime_source == 'tex'


### PR DESCRIPTION
- Add a `LsstLatexDoc.revision_datetime` attribute to access the latest revision date metadata of a LaTeX document. This property uses a set value in the `\date` command, if available. Otherwise, it falls back to the timestamp of the most recent Git commit that affected content (files with `tex`, `bib`, `pdf`, `png`, and `jpg` extensions). The final fallback is the current time. The `LsstLatexDoc.revision_datetime_source` attribute describes how the date was computed: `tex`, `git`, or `now`.
- New `metasrc.git.timestamp` module for accessing commit dates from a local Git repository.
- New dependency on `pytz`.
- New dependency on `GitPython`.
