### PR TITLE
DM-12569: Fix Pandoc auto-downloading (constrain to v1.19.1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change Log
 ##########
 
+0.2.2 (2017-11-20)
+==================
+
+- Constrain ``pypandoc.download_pandoc`` to specifically install Pandoc 1.19.1 rather than the latest Pandoc.
+  We think that Pandoc 2.0+ may be incompatible with pypandoc 1.4's download function.
+  See `DM-12569 <https://jira.lsstcorp.org/browse/DM-12569>`_ for details.
+- Update pytest to 3.2.5 and pytest-flake8 to 0.9.1 to solve incompatibilities in the floating indirect dependencies.
+
 0.2.1 (2017-10-09)
 ==================
 

--- a/metasrc/pandoc/convert.py
+++ b/metasrc/pandoc/convert.py
@@ -26,7 +26,11 @@ def ensure_pandoc(func):
             # Install pandoc and retry
             message = "pandoc needed but not found. Now installing it for you."
             logger.warning(message)
-            pypandoc.download_pandoc()
+            # This version of pandoc is known to be compatible with both
+            # pypandoc.download_pandoc and the functionality that metasrc
+            # needs. Travis CI tests are useful for ensuring download_pandoc
+            # works.
+            pypandoc.download_pandoc(version='1.19.1')
             logger.debug("pandoc download complete")
 
             result = func(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 -e .
 
 # Development/testing dependencies
-pytest==3.2.2
+pytest==3.2.5
 pytest-cov==2.5.0
-pytest-flake8==0.8.1
+pytest-flake8==0.9.1


### PR DESCRIPTION
- Constrain ``pypandoc.download_pandoc`` to specifically install Pandoc 1.19.1 rather than the latest Pandoc. We think that Pandoc 2.0+ may be incompatible with pypandoc 1.4's download function. See [DM-12569](https://jira.lsstcorp.org/browse/DM-12569) for details.
- Update pytest to 3.2.5 and pytest-flake8 to 0.9.1 to solve incompatibilities.